### PR TITLE
Feature/hb 35 and 37/improve styling front page, Increase main container to allow more width for card section

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -72,7 +72,7 @@ export default function Home({ allPosts: { edges }, preview }) {
                       }
                     />
                     <Card.Body>
-                      <Card.Title className="text-center">
+                      <Card.Title className="text-center text-truncate">
                         {node.title}
                       </Card.Title>
                     </Card.Body>

--- a/styles/_overrides.scss
+++ b/styles/_overrides.scss
@@ -1,5 +1,11 @@
 .card {
   border-radius: 4px;
+  height: clamp(18rem, 18rem, 22rem);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  img {
+    aspect-ratio: 16/9;
+  }
 }
 
 .btn {

--- a/styles/_overrides.scss
+++ b/styles/_overrides.scss
@@ -1,11 +1,12 @@
 .card {
   border-radius: 4px;
-  height: clamp(18rem, 18rem, 22rem);
-  overflow: hidden;
-  text-overflow: ellipsis;
   img {
     aspect-ratio: 16/9;
   }
+}
+
+.home {
+  max-width: 1450px;
 }
 
 .btn {


### PR DESCRIPTION
Aspect ratio added so all card images are 16x9 and the cards look consistent. Max width set to 1450px so the main body container aligns with the carousel image and more space for cards. Text-truncate class added from bootstrap to make the cards look nice and consistent until HB-36 is completed. ![Screen Shot 2022-05-19 at 8 23 36 AM](https://user-images.githubusercontent.com/22159808/169335346-04140d9b-dbca-4704-af07-b7c5c9a162fb.png)