### PR TITLE
Trimmed long titles, decreased font size, formatted card sizes to be uniformed

### DIFF
--- a/styles/_overrides.scss
+++ b/styles/_overrides.scss
@@ -1,8 +1,22 @@
 .card {
   border-radius: 4px;
+  min-height: 200px;
   img {
     aspect-ratio: 16/9;
   }
+}
+
+.card-body {
+  min-height: 125px;
+  max-height: 200px;
+}
+
+.card-title {
+  font-size: 1.1rem;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  white-space: normal;
 }
 
 .home {


### PR DESCRIPTION
- Titles are 3 lines and are truncated with ellipses to show the title is longer
- Decreased font size slightly to allow for more of the title to be shown
- Formatted card sizes so that all cards are uniform in size